### PR TITLE
refine for plugins settings dialog

### DIFF
--- a/BasicCAT/Preferences.bas
+++ b/BasicCAT/Preferences.bas
@@ -394,12 +394,16 @@ Sub loadFont
 End Sub
 
 Sub changePluginPathButton_MouseClicked (EventData As MouseEvent)
+	Dim path As String
 	Dim dc As DirectoryChooser
 	dc.Initialize
-	pluginDirLabel.Text=dc.Show(frm)
-	unsavedPreferences.Put("pluginDir",pluginDirLabel.Text)
-	loadPluginsList
-	Main.loadPlugins
+	path=dc.Show(frm)
+	If path<>"" Then
+		pluginDirLabel.Text=path
+		unsavedPreferences.Put("pluginDir",path)
+		loadPluginsList
+		Main.loadPlugins
+	End If
 End Sub
 
 Sub AddPluginButton_MouseClicked (EventData As MouseEvent)

--- a/BasicCAT/Preferences.bas
+++ b/BasicCAT/Preferences.bas
@@ -397,6 +397,8 @@ Sub changePluginPathButton_MouseClicked (EventData As MouseEvent)
 	Dim path As String
 	Dim dc As DirectoryChooser
 	dc.Initialize
+	dc.InitialDirectory=pluginDirLabel.Text
+	dc.Title="Select the directory where the plugins is located"
 	path=dc.Show(frm)
 	If path<>"" Then
 		pluginDirLabel.Text=path
@@ -410,6 +412,7 @@ Sub AddPluginButton_MouseClicked (EventData As MouseEvent)
 	Dim path As String
 	Dim fc As FileChooser
 	fc.Initialize
+	fc.Title="Adding a plugin to the Plugins folder"
 	fc.SetExtensionFilter("plugins",Array As String("*.jar"))
 	path=fc.ShowOpen(frm)
 	If path<>"" Then

--- a/BasicCAT/Preferences.bas
+++ b/BasicCAT/Preferences.bas
@@ -398,7 +398,7 @@ Sub changePluginPathButton_MouseClicked (EventData As MouseEvent)
 	Dim dc As DirectoryChooser
 	dc.Initialize
 	dc.InitialDirectory=pluginDirLabel.Text
-	dc.Title="Select the directory where the plugins is located"
+	dc.Title="Select the directory where the plugins are located"
 	path=dc.Show(frm)
 	If path<>"" Then
 		pluginDirLabel.Text=path


### PR DESCRIPTION
1. 避免选择插件目录的对话框取消后置空。
2. 默认显示当前插件目录。缺点，对话框好像只能显示空（没有文件夹）。
3. 添加标题以明确作用。